### PR TITLE
Support newer Transformers versions.

### DIFF
--- a/cut_cross_entropy/transformers/gemma2.py
+++ b/cut_cross_entropy/transformers/gemma2.py
@@ -6,23 +6,13 @@ import torch
 import transformers
 from transformers.cache_utils import HybridCache
 from transformers.modeling_outputs import CausalLMOutputWithPast
-from transformers.models.gemma2.modeling_gemma2 import (
-    _CONFIG_FOR_DOC,
-    GEMMA2_INPUTS_DOCSTRING,
-    logger,
-)
-from transformers.utils import (
-    add_start_docstrings_to_model_forward,
-    replace_return_docstrings,
-)
+from transformers.models.gemma2.modeling_gemma2 import logger
 
 from .utils import PatchOptions, TransformersModelT, apply_lce
 
 _PATCH_OPTS: PatchOptions | None = None
 
 
-@add_start_docstrings_to_model_forward(GEMMA2_INPUTS_DOCSTRING)
-@replace_return_docstrings(output_type=CausalLMOutputWithPast, config_class=_CONFIG_FOR_DOC)
 def cce_forward(
     self,
     input_ids: torch.LongTensor = None,

--- a/cut_cross_entropy/transformers/llama.py
+++ b/cut_cross_entropy/transformers/llama.py
@@ -7,24 +7,12 @@ import torch.nn.functional as F
 import transformers
 from transformers.cache_utils import Cache
 from transformers.modeling_outputs import CausalLMOutputWithPast
-from transformers.models.llama.modeling_llama import (
-    _CONFIG_FOR_DOC,
-    LLAMA_INPUTS_DOCSTRING,
-    KwargsForCausalLM,
-    Unpack,
-)
-from transformers.utils import (
-    add_start_docstrings_to_model_forward,
-    replace_return_docstrings,
-)
 
 from .utils import PatchOptions, TransformersModelT, apply_lce
 
 _PATCH_OPTS: PatchOptions | None = None
 
 
-@add_start_docstrings_to_model_forward(LLAMA_INPUTS_DOCSTRING)
-@replace_return_docstrings(output_type=CausalLMOutputWithPast, config_class=_CONFIG_FOR_DOC)
 def cce_forward(
     self,
     input_ids: torch.LongTensor = None,
@@ -39,7 +27,7 @@ def cce_forward(
     return_dict: Optional[bool] = None,
     cache_position: Optional[torch.LongTensor] = None,
     num_logits_to_keep: int = 0,
-    **kwargs: Unpack[KwargsForCausalLM],
+    **kwargs,
 ) -> Union[Tuple, CausalLMOutputWithPast]:
     r"""
     Args:

--- a/cut_cross_entropy/transformers/mistral.py
+++ b/cut_cross_entropy/transformers/mistral.py
@@ -7,24 +7,12 @@ import torch.distributed
 import transformers
 from transformers.cache_utils import Cache
 from transformers.modeling_outputs import CausalLMOutputWithPast
-from transformers.models.mistral.modeling_mistral import (
-    _CONFIG_FOR_DOC,
-    MISTRAL_INPUTS_DOCSTRING,
-    KwargsForCausalLM,
-    Unpack,
-)
-from transformers.utils import (
-    add_start_docstrings_to_model_forward,
-    replace_return_docstrings,
-)
 
 from .utils import PatchOptions, TransformersModelT, apply_lce
 
 _PATCH_OPTS: PatchOptions | None = None
 
 
-@add_start_docstrings_to_model_forward(MISTRAL_INPUTS_DOCSTRING)
-@replace_return_docstrings(output_type=CausalLMOutputWithPast, config_class=_CONFIG_FOR_DOC)
 def cce_forward(
     self,
     input_ids: torch.LongTensor = None,
@@ -39,7 +27,7 @@ def cce_forward(
     return_dict: Optional[bool] = None,
     cache_position: Optional[torch.LongTensor] = None,
     num_logits_to_keep: int = 0,
-    **kwargs: Unpack[KwargsForCausalLM],
+    **kwargs,
 ) -> Union[Tuple, CausalLMOutputWithPast]:
     r"""
     Args:

--- a/cut_cross_entropy/transformers/phi3.py
+++ b/cut_cross_entropy/transformers/phi3.py
@@ -6,24 +6,12 @@ import torch
 import transformers
 from transformers.cache_utils import Cache
 from transformers.modeling_outputs import CausalLMOutputWithPast
-from transformers.models.phi3.modeling_phi3 import (
-    _CONFIG_FOR_DOC,
-    PHI3_INPUTS_DOCSTRING,
-    KwargsForCausalLM,
-    Unpack,
-)
-from transformers.utils import (
-    add_start_docstrings_to_model_forward,
-    replace_return_docstrings,
-)
 
 from .utils import PatchOptions, TransformersModelT, apply_lce
 
 _PATCH_OPTS: PatchOptions | None = None
 
 
-@add_start_docstrings_to_model_forward(PHI3_INPUTS_DOCSTRING)
-@replace_return_docstrings(output_type=CausalLMOutputWithPast, config_class=_CONFIG_FOR_DOC)
 def cce_forward(
     self,
     input_ids: torch.LongTensor = None,
@@ -38,7 +26,7 @@ def cce_forward(
     return_dict: Optional[bool] = None,
     cache_position: Optional[torch.LongTensor] = None,
     num_logits_to_keep: int = 0,
-    **kwargs: Unpack[KwargsForCausalLM],
+    **kwargs,
 ) -> Union[Tuple, CausalLMOutputWithPast]:
     r"""
     Args:

--- a/cut_cross_entropy/transformers/qwen2.py
+++ b/cut_cross_entropy/transformers/qwen2.py
@@ -6,24 +6,12 @@ import torch
 import transformers
 from transformers.cache_utils import Cache
 from transformers.modeling_outputs import CausalLMOutputWithPast
-from transformers.models.qwen2.modeling_qwen2 import (
-    _CONFIG_FOR_DOC,
-    QWEN2_INPUTS_DOCSTRING,
-    KwargsForCausalLM,
-    Unpack,
-)
-from transformers.utils import (
-    add_start_docstrings_to_model_forward,
-    replace_return_docstrings,
-)
 
 from .utils import PatchOptions, TransformersModelT, apply_lce
 
 _PATCH_OPTS: PatchOptions | None = None
 
 
-@add_start_docstrings_to_model_forward(QWEN2_INPUTS_DOCSTRING)
-@replace_return_docstrings(output_type=CausalLMOutputWithPast, config_class=_CONFIG_FOR_DOC)
 def cce_forward(
     self,
     input_ids: torch.LongTensor = None,
@@ -38,7 +26,7 @@ def cce_forward(
     return_dict: Optional[bool] = None,
     cache_position: Optional[torch.LongTensor] = None,
     num_logits_to_keep: int = 0,
-    **kwargs: Unpack[KwargsForCausalLM],
+    **kwargs,
 ) -> Union[Tuple, CausalLMOutputWithPast]:
     r"""
     Args:


### PR DESCRIPTION
Removed model forward docstring decorators and related imports from the patched Llama, Mistral, Qwen2, Phi-3, and Gemma2 shims to avoid relying on utilities missing in newer Transformers versions.