### PR TITLE
Fix invalid target matching in vocab-parallel CCE kernels

### DIFF
--- a/cut_cross_entropy/cce_backward.py
+++ b/cut_cross_entropy/cce_backward.py
@@ -204,7 +204,7 @@ def _cce_backward_kernel(
             target_offs_b = offs_b
 
         targets = tl.load(Targets + target_offs_b, mask=target_offs_b < BMax, other=V + 1)
-        is_target = targets[:, None] == offs_v[None, :]
+        is_target = (targets[:, None] == offs_v[None, :]) & (offs_v[None, :] < V)
         d_accum += tl.where(is_target, -1.0, 0.0)
     else:
         is_target = None

--- a/cut_cross_entropy/cce_lse_forward.py
+++ b/cut_cross_entropy/cce_lse_forward.py
@@ -116,7 +116,8 @@ def _cce_lse_forward_kernel(
         neg_correct_logit_ptrs = tl.broadcast_to(
             neg_correct_logit_ptrs[:, None], (BLOCK_B, BLOCK_V)
         )
-        tl.store(neg_correct_logit_ptrs, -logits, mask=this_targets[:, None] == offs_v[None, :])
+        is_target = (this_targets[:, None] == offs_v[None, :]) & (offs_v[None, :] < V)
+        tl.store(neg_correct_logit_ptrs, -logits, mask=is_target)
     else:
         offs_b = (pid_b * BLOCK_B + tl.arange(0, BLOCK_B)).to(tl.int64)
 


### PR DESCRIPTION
This PR fixes a bug in cut_cross_entropy’s cce vocab-parallel path.

When a target token falls outside the local vocab shard, the forward kernel uses a sentinel index. In the last vocab tile, that sentinel could incorrectly match a padded invalid column, causing `neg_correct_logit` to become `inf` and the final loss to blow up to `inf`. This PR adds an `offs_v < V` guard in both the forward and backward kernels so only valid vocab columns can be treated as targets.
